### PR TITLE
fix: Remove methods for removed marking fields

### DIFF
--- a/src/Model/Marking/DynamicFixedPrice.php
+++ b/src/Model/Marking/DynamicFixedPrice.php
@@ -13,9 +13,6 @@ class DynamicFixedPrice
     private $value;
 
     /** @var string */
-    private $reducedValue;
-
-    /** @var string */
     private $calculationValue;
 
     /** @var string */
@@ -55,18 +52,6 @@ class DynamicFixedPrice
     public function setValue(string $value): self
     {
         $this->value = $value;
-
-        return $this;
-    }
-
-    public function getReducedValue(): ?string
-    {
-        return $this->reducedValue;
-    }
-
-    public function setReducedValue(?string $reducedValue): self
-    {
-        $this->reducedValue = $reducedValue;
 
         return $this;
     }

--- a/src/Model/Marking/MarkingPrice.php
+++ b/src/Model/Marking/MarkingPrice.php
@@ -14,9 +14,6 @@ class MarkingPrice
     private $value;
 
     /** @var string */
-    private $reducedValue;
-
-    /** @var string */
     private $calculationValue;
 
     public function getId(): string
@@ -63,18 +60,6 @@ class MarkingPrice
     public function setCalculationValue(string $calculationValue): self
     {
         $this->calculationValue = $calculationValue;
-
-        return $this;
-    }
-
-    public function getReducedValue(): ?string
-    {
-        return $this->reducedValue;
-    }
-
-    public function setReducedValue(?string $reducedValue): self
-    {
-        $this->reducedValue = $reducedValue;
 
         return $this;
     }

--- a/src/Model/Marking/StaticFixedPrice.php
+++ b/src/Model/Marking/StaticFixedPrice.php
@@ -13,9 +13,6 @@ class StaticFixedPrice
     private $value;
 
     /** @var string */
-    private $reducedValue;
-
-    /** @var string */
     private $calculationValue;
 
     /** @var string */
@@ -55,18 +52,6 @@ class StaticFixedPrice
     public function setValue(?string $value): self
     {
         $this->value = $value;
-
-        return $this;
-    }
-
-    public function getReducedValue(): ?string
-    {
-        return $this->reducedValue;
-    }
-
-    public function setReducedValue(?string $reducedValue): self
-    {
-        $this->reducedValue = $reducedValue;
 
         return $this;
     }

--- a/src/Model/Marking/SupplierOptionPrice.php
+++ b/src/Model/Marking/SupplierOptionPrice.php
@@ -11,9 +11,6 @@ class SupplierOptionPrice
     private $value;
 
     /** @var float */
-    private $reducedValue;
-
-    /** @var float */
     private $calculationValue;
 
     public function getFromQuantity(): int
@@ -36,18 +33,6 @@ class SupplierOptionPrice
     public function setValue(float $value): SupplierOptionPrice
     {
         $this->value = $value;
-
-        return $this;
-    }
-
-    public function getReducedValue(): ?float
-    {
-        return $this->reducedValue;
-    }
-
-    public function setReducedValue(?float $reducedValue): SupplierOptionPrice
-    {
-        $this->reducedValue = $reducedValue;
 
         return $this;
     }

--- a/src/Model/Price.php
+++ b/src/Model/Price.php
@@ -22,11 +22,6 @@ class Price implements \JsonSerializable
     /**
      * @var float
      */
-    private $reducedValue;
-
-    /**
-     * @var float
-     */
     private $calculationValue;
 
     /**
@@ -97,26 +92,6 @@ class Price implements \JsonSerializable
     /**
      * @return float
      */
-    public function getReducedValue()
-    {
-        return $this->reducedValue;
-    }
-
-    /**
-     * @param float $reducedValue
-     *
-     * @return Price
-     */
-    public function setReducedValue($reducedValue)
-    {
-        $this->reducedValue = $reducedValue;
-
-        return $this;
-    }
-
-    /**
-     * @return float
-     */
     public function getCalculationValue()
     {
         return $this->calculationValue;
@@ -163,7 +138,6 @@ class Price implements \JsonSerializable
             'id' => $this->id,
             'from_quantity' => $this->fromQuantity,
             'value' => $this->value,
-            'reduced_value' => $this->reducedValue,
             'calculation_value' => $this->calculationValue,
             'supplier_profile' => $this->supplierProfile
         ];

--- a/src/Normalizer/Marking/DynamicFixedPriceNormalizer.php
+++ b/src/Normalizer/Marking/DynamicFixedPriceNormalizer.php
@@ -11,7 +11,6 @@ class DynamicFixedPriceNormalizer
         $dynamicFixedPrice = new DynamicFixedPrice();
         $dynamicFixedPrice->setId($data['id']);
         $dynamicFixedPrice->setValue($data['value']);
-        $dynamicFixedPrice->setReducedValue($data['reduced_value']);
         $dynamicFixedPrice->setCalculationValue($data['calculation_value']);
         $dynamicFixedPrice->setCondition($data['condition']);
         $dynamicFixedPrice->setTotalPrice((bool) $data['total_price']);

--- a/src/Normalizer/Marking/MarkingPriceNormalizer.php
+++ b/src/Normalizer/Marking/MarkingPriceNormalizer.php
@@ -12,7 +12,6 @@ class MarkingPriceNormalizer
         $markingPrice->setId($data['id']);
         $markingPrice->setFromQuantity($data['from_quantity']);
         $markingPrice->setValue($data['value']);
-        $markingPrice->setReducedValue($data['reduced_value'] ?? null);
         $markingPrice->setCalculationValue($data['calculation_value']);
 
         return $markingPrice;

--- a/src/Normalizer/Marking/StaticFixedPriceNormalizer.php
+++ b/src/Normalizer/Marking/StaticFixedPriceNormalizer.php
@@ -11,7 +11,6 @@ class StaticFixedPriceNormalizer
         $staticFixedPrice = new StaticFixedPrice();
         $staticFixedPrice->setId($data['id']);
         $staticFixedPrice->setValue($data['value']);
-        $staticFixedPrice->setReducedValue($data['reduced_value']);
         $staticFixedPrice->setCalculationValue($data['calculation_value']);
         $staticFixedPrice->setCondition($data['condition']);
         $staticFixedPrice->setTotalPrice((bool) $data['total_price']);

--- a/src/Normalizer/Marking/SupplierOptionPriceNormalizer.php
+++ b/src/Normalizer/Marking/SupplierOptionPriceNormalizer.php
@@ -11,7 +11,6 @@ class SupplierOptionPriceNormalizer
         $supplierOptionPrice = new SupplierOptionPrice();
         $supplierOptionPrice->setFromQuantity($data['from_quantity']);
         $supplierOptionPrice->setValue($data['value']);
-        $supplierOptionPrice->setReducedValue($data['reduced_value']);
         $supplierOptionPrice->setCalculationValue($data['calculation_value']);
 
         return $supplierOptionPrice;

--- a/src/Normalizer/PriceNormalizer.php
+++ b/src/Normalizer/PriceNormalizer.php
@@ -16,7 +16,6 @@ class PriceNormalizer
         $price = new Price();
         $price->setId($data['id']);
         $price->setValue($data['value']);
-        $price->setReducedValue($data['reduced_value']);
 
         // for sample price
         if (isset($data['from_quantity'])) {


### PR DESCRIPTION
BREAKING CHANGE:
- Remove all methods setReducedValue and getReducedValue of Price, SupplierOptionPrice, StaticFixedPrice, MarkingPrice and DynamicFixedPrice classes
- "reduced_value" key no longer returned by JSON serialization of Price objects

Close 13428